### PR TITLE
Remove codesigning-phase in script

### DIFF
--- a/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
+++ b/Sources/LaunchAtLogin/copy-helper-swiftpm.sh
@@ -38,12 +38,6 @@ unzip "$helper_path" -d "$login_items/"
 
 defaults write "$login_helper_path/Contents/Info" CFBundleIdentifier -string "$PRODUCT_BUNDLE_IDENTIFIER-LaunchAtLoginHelper"
 
-if [[ -n $CODE_SIGN_ENTITLEMENTS ]]; then
-	codesign --force --entitlements="$package_resources_path/LaunchAtLogin.entitlements" --deep --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$login_helper_path"
-else
-	codesign --force --deep --options=runtime --sign="$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$helper_path"
-fi
-
 # If this is being built for multiple architectures, assume it is a release build and we should clean up.
 if [[ $ONLY_ACTIVE_ARCH != "YES" ]]; then
 	rm -rf "$contents_path/Resources/LaunchAtLogin_LaunchAtLogin.bundle"


### PR DESCRIPTION
We ran into an issue where the code-sign fails in the run-script phase related to LaunchAtLogin, this happened in the pipeline. 

I removed the codesigning part in the `copy-helper-swiftpm.sh` because it is not needed in our case. As we build our build using the pipeline and the latter already signs all files in the bundle, including the helper.
